### PR TITLE
build: Add features for platform-specific code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,12 @@ name = "ent"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["stone", "summit"]
+stone = ["dep:stone_recipe"]
+summit = []
+ypkg = []
+
 [dependencies]
 clap = { version = "4.5.20", features = ["derive"] }
 colored = "2.1.0"
@@ -14,6 +20,6 @@ reqwest = { version = "0.12.9", features = ["json"] }
 serde = { version = "1.0.214", features = ["derive"] }
 serde_json = "1.0.132"
 serde_yaml = "0.9.34"
-stone_recipe = { git = "https://github.com/serpent-os/tools.git", version = "0.24.2" }
+stone_recipe = { git = "https://github.com/serpent-os/tools.git", version = "0.24.2", optional = true }
 thiserror = "2.0.9"
 tokio = { version = "1.41.0", features = ["macros"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ enum Commands {
         check_command: CheckCommands,
     },
     /// List recent builds from Summit
+    #[cfg(feature = "summit")]
     Builds,
 }
 
@@ -239,6 +240,7 @@ async fn check_updates(root: impl AsRef<Path>) -> Result<(), Box<dyn std::error:
 }
 
 /// Fetches and displays the current builds from Summit
+#[cfg(feature = "summit")]
 async fn list_builds() -> Result<(), Box<dyn std::error::Error>> {
     let client = reqwest::Client::new();
 
@@ -374,6 +376,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 todo!("Implement security check");
             }
         },
+        #[cfg(feature = "summit")]
         Commands::Builds => {
             list_builds().await?;
         }

--- a/src/recipes/mod.rs
+++ b/src/recipes/mod.rs
@@ -10,7 +10,10 @@ mod parser;
 use monitoring::Monitoring;
 pub use parser::*;
 
+#[cfg(feature = "stone")]
 mod stone;
+
+#[cfg(feature = "ypkg")]
 mod ypkg;
 
 // Source recipe details


### PR DESCRIPTION
This moves platform-specific code, such as the handling of `stone` and
`ypkg` recipes, behind Cargo features. Aeryn doesn't need to deal with
Solus packages, and vice-versa (at least for the time being).

By default, the `summit` and `stone` features are enabled.

Fixes https://github.com/AerynOS/ent/issues/3
