### PR TITLE
main: Color versions based on semver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,6 +254,7 @@ dependencies = [
  "indicatif",
  "inventory",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -1099,6 +1100,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,10 @@ glob = "0.3.1"
 indicatif = "0.17.8"
 inventory = "0.3.15"
 reqwest = { version = "0.12.9", features = ["json"] }
+semver = "1.0.26"
 serde = { version = "1.0.214", features = ["derive"] }
 serde_json = "1.0.132"
 serde_yaml = "0.9.34"
 stone_recipe = { git = "https://github.com/serpent-os/tools.git", version = "0.24.2" }
 thiserror = "2.0.9"
-tokio = { version = "1.41.0", features = ["macros"] }
+tokio = { version = "1.41.0", features = ["macros", 'rt-multi-thread'] }


### PR DESCRIPTION
This changes the output coloring of update versions based on semver. If
both versions being compared follow semver, then we have the following
cases:

- The current version is greater than or equal to the "latest" version
- The latest version has a greater major version number
- The latest version has a greater minor or patch version number

The color of the latest version is chosen based on what
`yarn update-interactive` does (sorta). In the first case above, the
color will be gray (technically light black). In the second case, red,
and lastly, yellow. This helps the user estimate at a glance what to
look for while performing and testing a package update.

If at least one of the versions cannot be parsed as semver, then the
color will simply be red.

Fixes https://github.com/AerynOS/ent/issues/9
